### PR TITLE
upgrading velero-aws-plugin to v1.1.0

### DIFF
--- a/build/velero-aws-plugin/Dockerfile
+++ b/build/velero-aws-plugin/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.14-alpine as build
 
-ARG VERSION=v1.0.0
+ARG VERSION=v1.1.0
 ARG TARGETPLATFORM
 
 ENV GO111MODULE=on \


### PR DESCRIPTION
# Description

This upgrades the velero-aws-plugin to v1.1.0 to stay in sync with upstream

## Type Of Change

To help us figure out who should review this PR, please put an X in all the areas that this PR affects.

- [ ] Docs
- [x] Installation
- [ ] Performance and Scalability
- [ ] Security
- [ ] Test and/or Release
- [x] User Experience
