### PR TITLE
fix the helm-operator schedule

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Fetch helm-operator release version
         run: |
           curl -sL https://api.github.com/repos/fluxcd/helm-operator/tags | \
-          jq -r '.[0].name'
+          jq -r '.[0].name' > build/helm-operator/.version
 
       - name: Fetch gatekeeper release version
         run: |


### PR DESCRIPTION
Signed-off-by: Michael Fornaro <20387402+xUnholy@users.noreply.github.com>

# Description

The schedule for the helm-operator was not triggering new builds for the latest upstream release.

## Type Of Change

To help us figure out who should review this PR, please put an X in all the areas that this PR affects.

- [ ] Docs
- [x] Installation
- [ ] Performance and Scalability
- [ ] Security
- [ ] Test and/or Release
- [ ] User Experience

## Issue Ref (Optional)

Which issue(s) this PR fixes (optional, using fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when the PR gets merged): Fixes #

## Notes

Add special notes for your reviewer here.
