### PR TITLE
Changing USER of csi-external images

### DIFF
--- a/build/csi-external-attacher/Dockerfile
+++ b/build/csi-external-attacher/Dockerfile
@@ -17,6 +17,6 @@ LABEL description="CSI External Attacher"
 
 COPY --from=builder /go/src/github.com/kubernetes-csi/external-attacher/bin/csi-attacher csi-attacher
 
-USER nonroot:nonroot
+USER 0:0
 
 ENTRYPOINT ["/csi-attacher"]

--- a/build/csi-external-provisioner/Dockerfile
+++ b/build/csi-external-provisioner/Dockerfile
@@ -17,6 +17,6 @@ LABEL description="CSI External provisioner"
 
 COPY --from=builder /go/src/github.com/kubernetes-csi/external-provisioner/bin/csi-provisioner csi-provisioner
 
-USER nonroot:nonroot
+USER 0:0
 
 ENTRYPOINT ["/csi-provisioner"]

--- a/build/csi-external-resizer/Dockerfile
+++ b/build/csi-external-resizer/Dockerfile
@@ -17,6 +17,6 @@ LABEL description="CSI External resizer"
 
 COPY --from=builder /go/src/github.com/kubernetes-csi/external-resizer/bin/csi-resizer csi-resizer
 
-USER nonroot:nonroot
+USER 0:0
 
 ENTRYPOINT ["/csi-resizer"]

--- a/build/csi-external-snapshotter/Dockerfile
+++ b/build/csi-external-snapshotter/Dockerfile
@@ -20,6 +20,6 @@ LABEL description="CSI External snapshotter"
 
 COPY --from=builder /go/src/github.com/kubernetes-csi/external-snapshotter/bin/csi-snapshotter csi-snapshotter
 
-USER nonroot:nonroot
+USER 0:0
 
 ENTRYPOINT ["/csi-snapshotter"]

--- a/build/csi-node-driver-registrar/Dockerfile
+++ b/build/csi-node-driver-registrar/Dockerfile
@@ -17,6 +17,6 @@ LABEL description="CSI Node Driver Registrar"
 
 COPY --from=builder /go/src/github.com/kubernetes-csi/node-driver-registrar/bin/csi-node-driver-registrar csi-node-driver-registrar
 
-USER nonroot:nonroot
+USER 0:0
 
 ENTRYPOINT ["/csi-node-driver-registrar"]


### PR DESCRIPTION
# Description

When running as "nonroot" user, the csi processes have no access to the csi socket. This results in the csi containers showing the following over and over in the logs:
```
1 feature_gate.go:243] feature gates: &{map[]}
1 csi-provisioner.go:107] Version: v1.6.0-0-g321fa5c
1 csi-provisioner.go:121] Building kube configs for running in cluster...
1 connection.go:153] Connecting to unix:///csi/csi-provisioner.sock
1 connection.go:172] Still connecting to unix:///csi/csi-provisioner.sock
1 connection.go:172] Still connecting to unix:///csi/csi-provisioner.sock
1 connection.go:172] Still connecting to unix:///csi/csi-provisioner.sock
[...]
```

After the change of `nonroot:nonroot` to `0:0`, it started working like normal again:
```
1 feature_gate.go:243] feature gates: &{map[]}
1 csi-provisioner.go:107] Version: v1.6.0-0-g321fa5c
1 csi-provisioner.go:121] Building kube configs for running in cluster...
1 connection.go:153] Connecting to unix:///csi/csi-provisioner.sock
1 common.go:111] Probing CSI driver for readiness
1 connection.go:182] GRPC call: /csi.v1.Identity/Probe
[...]
```
## Type Of Change

To help us figure out who should review this PR, please put an X in all the areas that this PR affects.

- [ ] Docs
- [ ] Installation
- [ ] Performance and Scalability
- [ ] Security
- [X] Test and/or Release
- [X] User Experience