### PR TITLE
Fixing incorrect copy in velero-aws-plugin Dockerfile

### DIFF
--- a/build/velero-aws-plugin/Dockerfile
+++ b/build/velero-aws-plugin/Dockerfile
@@ -15,14 +15,14 @@ RUN export GOOS=$(echo ${TARGETPLATFORM} | cut -d / -f1) && \
     GOARM=$(echo ${TARGETPLATFORM} | cut -d / -f3 | cut -c2-) && \
     git clone --depth 1 -b ${VERSION} https://github.com/vmware-tanzu/velero-plugin-for-aws.git . && \
     go mod init && \
-    go build -mod=mod -o velero-plugin-for-aws ./velero-plugin-for-aws
+    go build -mod=mod -o /go/bin/velero-plugin-for-aws ./velero-plugin-for-aws
 
-FROM alpine:3.11
+FROM alpine:3.12
 
 WORKDIR /plugins
 
 RUN apk add --no-cache bash ca-certificates
 
-COPY --from=build /go/src/github.com/vmware-tanzu/velero-plugin-for-aws/velero-plugin-for-aws ./velero-plugin-for-aws
+COPY --from=build /go/bin/velero-plugin-for-aws ./velero-plugin-for-aws
 
 ENTRYPOINT ["/bin/bash", "-c", "cp /plugins/* /target/."]

--- a/build/velero-gcp-plugin/Dockerfile
+++ b/build/velero-gcp-plugin/Dockerfile
@@ -15,14 +15,14 @@ RUN export GOOS=$(echo ${TARGETPLATFORM} | cut -d / -f1) && \
     GOARM=$(echo ${TARGETPLATFORM} | cut -d / -f3 | cut -c2-) && \
     git clone --depth 1 -b ${VERSION} https://github.com/vmware-tanzu/velero-plugin-for-gcp.git . && \
     go mod init && \
-    go build -mod=mod -o velero-plugin-for-gcp ./velero-plugin-for-gcp
+    go build -mod=mod -o /go/bin/velero-plugin-for-gcp ./velero-plugin-for-gcp
 
-FROM alpine:3.11
+FROM alpine:3.12
 
 WORKDIR /plugins
 
 RUN apk add --no-cache bash ca-certificates
 
-COPY --from=build /go/src/github.com/vmware-tanzu/velero-plugin-for-gcp/velero-plugin-for-gcp ./velero-plugin-for-gcp
+COPY --from=build /go/bin/velero-plugin-for-gcp ./velero-plugin-for-gcp
 
 ENTRYPOINT ["/bin/bash", "-c", "cp -r /plugins/* /target/."]


### PR DESCRIPTION
# Description

Instead of copying just the binary, the whole src folder got copied. The binary will now be compiled into `/go/bin/` and just the binary gets copied from the  build stage into the run stage.

## Type Of Change

- [ ] Docs
- [ ] Installation
- [ ] Performance and Scalability
- [ ] Security
- [ ] Test and/or Release
- [X] User Experience