### PR TITLE
fix tag truncation issue with kured workflow

### DIFF
--- a/.github/workflows/kured.yml
+++ b/.github/workflows/kured.yml
@@ -64,5 +64,4 @@ jobs:
           push: true
           tags: |
             raspbernetes/kured:latest
-            raspbernetes/kured${{ steps.prep.outputs.version }}
-
+            raspbernetes/kured:${{ steps.prep.outputs.version }}


### PR DESCRIPTION
# Description

[7a8dc46abae4f50c3dfbb230213858c96b9d0140](https://github.com/raspbernetes/multi-arch-images/commit/7a8dc46abae4f50c3dfbb230213858c96b9d0140#diff-468472a539d0314fc4dec5b58dcd702b) may have resulted in the removal of the `:` between the container image name and tag name.

As seen in the previous build output, the kured image name and tag name does not appear correct:
![image](https://user-images.githubusercontent.com/6393612/93089651-96c95f80-f669-11ea-969e-c3526f538a88.png)

The intent of this change is to remedy that issue.  If this is successful, the other existing workflows will be updated similarly.


## Type Of Change

- [ ] Docs
- [x] Installation
- [ ] Performance and Scalability
- [ ] Security
- [ ] Test and/or Release
- [x] User Experience
