### PR TITLE
fix docker image version tags

### DIFF
--- a/.github/workflows/cloudflared.yml
+++ b/.github/workflows/cloudflared.yml
@@ -64,4 +64,4 @@ jobs:
           push: true
           tags: |
             raspbernetes/cloudflared:latest
-            raspbernetes/cloudflared${{ steps.prep.outputs.version }}
+            raspbernetes/cloudflared:${{ steps.prep.outputs.version }}

--- a/.github/workflows/cluster-autoscaler.yml
+++ b/.github/workflows/cluster-autoscaler.yml
@@ -64,4 +64,4 @@ jobs:
           push: true
           tags: |
             raspbernetes/cluster-autoscaler:latest
-            raspbernetes/cluster-autoscaler${{ steps.prep.outputs.version }}
+            raspbernetes/cluster-autoscaler:${{ steps.prep.outputs.version }}

--- a/.github/workflows/csi-external-attacher.yml
+++ b/.github/workflows/csi-external-attacher.yml
@@ -64,4 +64,4 @@ jobs:
           push: true
           tags: |
             raspbernetes/csi-external-attacher:latest
-            raspbernetes/csi-external-attacher${{ steps.prep.outputs.version }}
+            raspbernetes/csi-external-attacher:${{ steps.prep.outputs.version }}

--- a/.github/workflows/csi-external-provisioner.yml
+++ b/.github/workflows/csi-external-provisioner.yml
@@ -64,4 +64,4 @@ jobs:
           push: true
           tags: |
             raspbernetes/csi-external-provisioner:latest
-            raspbernetes/csi-external-provisioner${{ steps.prep.outputs.version }}
+            raspbernetes/csi-external-provisioner:${{ steps.prep.outputs.version }}

--- a/.github/workflows/csi-external-resizer.yml
+++ b/.github/workflows/csi-external-resizer.yml
@@ -64,4 +64,4 @@ jobs:
           push: true
           tags: |
             raspbernetes/csi-external-resizer:latest
-            raspbernetes/csi-external-resizer${{ steps.prep.outputs.version }}
+            raspbernetes/csi-external-resizer:${{ steps.prep.outputs.version }}

--- a/.github/workflows/csi-external-snapshotter.yml
+++ b/.github/workflows/csi-external-snapshotter.yml
@@ -64,4 +64,4 @@ jobs:
           push: true
           tags: |
             raspbernetes/csi-external-snapshotter:latest
-            raspbernetes/csi-external-snapshotter${{ steps.prep.outputs.version }}
+            raspbernetes/csi-external-snapshotter:${{ steps.prep.outputs.version }}

--- a/.github/workflows/csi-node-driver-registrar.yml
+++ b/.github/workflows/csi-node-driver-registrar.yml
@@ -64,4 +64,4 @@ jobs:
           push: true
           tags: |
             raspbernetes/csi-node-driver-registrar:latest
-            raspbernetes/csi-node-driver-registrar${{ steps.prep.outputs.version }}
+            raspbernetes/csi-node-driver-registrar:${{ steps.prep.outputs.version }}

--- a/.github/workflows/dex-k8s-authenticator.yml
+++ b/.github/workflows/dex-k8s-authenticator.yml
@@ -64,4 +64,4 @@ jobs:
           push: true
           tags: |
             raspbernetes/dex-k8s-authenticator:latest
-            raspbernetes/dex-k8s-authenticator${{ steps.prep.outputs.version }}
+            raspbernetes/dex-k8s-authenticator:${{ steps.prep.outputs.version }}

--- a/.github/workflows/external-dns.yml
+++ b/.github/workflows/external-dns.yml
@@ -64,4 +64,4 @@ jobs:
           push: true
           tags: |
             raspbernetes/external-dns:latest
-            raspbernetes/external-dns${{ steps.prep.outputs.version }}
+            raspbernetes/external-dns:${{ steps.prep.outputs.version }}

--- a/.github/workflows/flagger.yml
+++ b/.github/workflows/flagger.yml
@@ -64,4 +64,4 @@ jobs:
           push: true
           tags: |
             raspbernetes/flagger:latest
-            raspbernetes/flagger${{ steps.prep.outputs.version }}
+            raspbernetes/flagger:${{ steps.prep.outputs.version }}

--- a/.github/workflows/flux.yml
+++ b/.github/workflows/flux.yml
@@ -64,4 +64,4 @@ jobs:
           push: true
           tags: |
             raspbernetes/flux:latest
-            raspbernetes/flux${{ steps.prep.outputs.version }}
+            raspbernetes/flux:${{ steps.prep.outputs.version }}

--- a/.github/workflows/ghostunnel.yml
+++ b/.github/workflows/ghostunnel.yml
@@ -64,4 +64,4 @@ jobs:
           push: true
           tags: |
             raspbernetes/ghostunnel:latest
-            raspbernetes/ghostunnel${{ steps.prep.outputs.version }}
+            raspbernetes/ghostunnel:${{ steps.prep.outputs.version }}

--- a/.github/workflows/helm-operator.yml
+++ b/.github/workflows/helm-operator.yml
@@ -64,5 +64,4 @@ jobs:
           push: true
           tags: |
             raspbernetes/helm-operator:latest
-            raspbernetes/helm-operator${{ steps.prep.outputs.version }}
-
+            raspbernetes/helm-operator:${{ steps.prep.outputs.version }}

--- a/.github/workflows/istio-base.yml
+++ b/.github/workflows/istio-base.yml
@@ -64,5 +64,4 @@ jobs:
           push: true
           tags: |
             raspbernetes/istio-base:latest
-            raspbernetes/istio-base${{ steps.prep.outputs.version }}
-
+            raspbernetes/istio-base:${{ steps.prep.outputs.version }}

--- a/.github/workflows/istio-operator.yml
+++ b/.github/workflows/istio-operator.yml
@@ -64,4 +64,4 @@ jobs:
           push: true
           tags: |
             raspbernetes/istio-operator:latest
-            raspbernetes/istio-operator${{ steps.prep.outputs.version }}
+            raspbernetes/istio-operator:${{ steps.prep.outputs.version }}

--- a/.github/workflows/istio-pilot.yml
+++ b/.github/workflows/istio-pilot.yml
@@ -65,4 +65,4 @@ jobs:
           push: true
           tags: |
             raspbernetes/istio-pilot:latest
-            raspbernetes/istio-pilot${{ steps.prep.outputs.version }}
+            raspbernetes/istio-pilot:${{ steps.prep.outputs.version }}

--- a/.github/workflows/istio-proxyv2.yml
+++ b/.github/workflows/istio-proxyv2.yml
@@ -65,4 +65,4 @@ jobs:
           push: true
           tags: |
             raspbernetes/istio-proxyv2:latest
-            raspbernetes/istio-proxyv2${{ steps.prep.outputs.version }}
+            raspbernetes/istio-proxyv2:${{ steps.prep.outputs.version }}

--- a/.github/workflows/kiali.yml
+++ b/.github/workflows/kiali.yml
@@ -65,5 +65,4 @@ jobs:
           push: true
           tags: |
             raspbernetes/kiali:latest
-            raspbernetes/kiali${{ steps.prep.outputs.version }}
-
+            raspbernetes/kiali:${{ steps.prep.outputs.version }}

--- a/.github/workflows/kube-bench.yml
+++ b/.github/workflows/kube-bench.yml
@@ -64,5 +64,4 @@ jobs:
           push: true
           tags: |
             raspbernetes/kube-bench:latest
-            raspbernetes/kube-bench${{ steps.prep.outputs.version }}
-
+            raspbernetes/kube-bench:${{ steps.prep.outputs.version }}

--- a/.github/workflows/kube-state-metrics.yml
+++ b/.github/workflows/kube-state-metrics.yml
@@ -64,5 +64,4 @@ jobs:
           push: true
           tags: |
             raspbernetes/kube-state-metrics:latest
-            raspbernetes/kube-state-metrics${{ steps.prep.outputs.version }}
-
+            raspbernetes/kube-state-metrics:${{ steps.prep.outputs.version }}

--- a/.github/workflows/kubectl.yml
+++ b/.github/workflows/kubectl.yml
@@ -64,4 +64,4 @@ jobs:
           push: true
           tags: |
             raspbernetes/kubectl:latest
-            raspbernetes/kubectl${{ steps.prep.outputs.version }}
+            raspbernetes/kubectl:${{ steps.prep.outputs.version }}

--- a/.github/workflows/kubeyaml.yml
+++ b/.github/workflows/kubeyaml.yml
@@ -64,5 +64,4 @@ jobs:
           push: true
           tags: |
             raspbernetes/kubeyaml:latest
-            raspbernetes/kubeyaml${{ steps.prep.outputs.version }}
-
+            raspbernetes/kubeyaml:${{ steps.prep.outputs.version }}

--- a/.github/workflows/kured.yml
+++ b/.github/workflows/kured.yml
@@ -64,5 +64,4 @@ jobs:
           push: true
           tags: |
             raspbernetes/kured:latest
-            raspbernetes/kured${{ steps.prep.outputs.version }}
-
+            raspbernetes/kured:${{ steps.prep.outputs.version }}

--- a/.github/workflows/kustomize.yml
+++ b/.github/workflows/kustomize.yml
@@ -69,5 +69,4 @@ jobs:
           push: true
           tags: |
             raspbernetes/kustomize:latest
-            raspbernetes/kustomize${{ steps.prep.outputs.docker_tag }}
-
+            raspbernetes/kustomize:${{ steps.prep.outputs.docker_tag }}

--- a/.github/workflows/sops.yml
+++ b/.github/workflows/sops.yml
@@ -64,5 +64,4 @@ jobs:
           push: true
           tags: |
             raspbernetes/sops:latest
-            raspbernetes/sops${{ steps.prep.outputs.version }}
-
+            raspbernetes/sops:${{ steps.prep.outputs.version }}

--- a/.github/workflows/velero-aws-plugin.yml
+++ b/.github/workflows/velero-aws-plugin.yml
@@ -64,5 +64,4 @@ jobs:
           push: true
           tags: |
             raspbernetes/velero-aws-plugin:latest
-            raspbernetes/velero-aws-plugin${{ steps.prep.outputs.version }}
-
+            raspbernetes/velero-aws-plugin:${{ steps.prep.outputs.version }}

--- a/.github/workflows/velero-gcp-plugin.yml
+++ b/.github/workflows/velero-gcp-plugin.yml
@@ -64,4 +64,4 @@ jobs:
           push: true
           tags: |
             raspbernetes/velero-gcp-plugin:latest
-            raspbernetes/velero-gcp-plugin${{ steps.prep.outputs.version }}
+            raspbernetes/velero-gcp-plugin:${{ steps.prep.outputs.version }}


### PR DESCRIPTION
# Description

Refactoring the docker build introduced a typo in most of the build workflows (missing colon), resulting in docker images named e.g. `docker.io/raspbernetes/kustomizev3.8.2:latest`.

This MR fixes this, and thus https://github.com/raspbernetes/multi-arch-images/issues/159 partially.

## Type Of Change

To help us figure out who should review this PR, please put an X in all the areas that this PR affects.

- [ ] Docs
- [ ] Installation
- [ ] Performance and Scalability
- [ ] Security
- [x] Test and/or Release
- [ ] User Experience


## Notes

Add special notes for your reviewer here.
