### PR TITLE
fix kustomize version auto-upgrade

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -118,10 +118,22 @@ jobs:
           curl -sL https://api.github.com/repos/weaveworks/kured/releases/latest | \
           jq -r ".tag_name" > build/kured/.version
 
+      # kustomize hosts different artifacts in one repo. releases and tags are named $COMPONENT/$VERSION
+      # so in order to get the newest kustomize release, retrieve a full page of 100 releases, and pick the
+      # first (newest) release having the prefix 'kustomize/' in its tag name. so this breaks as soon as
+      # they release 100 other items without releasing kustomize at least once.
       - name: Fetch kustomize release version
         run: |
-          curl -sL https://api.github.com/repos/kubernetes-sigs/kustomize/tags | \
-          jq -r '.[0].name' > build/kustomize/.version
+          KUSTOMIZE_VERSION=$(
+            curl -sL "https://api.github.com/repos/kubernetes-sigs/kustomize/releases?per_page=100" | \
+            jq -r '[ .[].tag_name | select(test("kustomize/.*")) ] | first // empty'
+          )
+
+          if [[ -z "${KUSTOMIZE_VERSION}" ]]; then
+            echo "Could not determine Kustomize version."
+          else
+            echo "${KUSTOMIZE_VERSION}" > build/kustomize/.version
+          fi
 
       - name: Fetch node-feature-discovery release version
         run: |


### PR DESCRIPTION
# Description

Change version scraping for kustomize in auto-upgrade workflow, make it compatible with their current release / tag scheme.

## Type Of Change

To help us figure out who should review this PR, please put an X in all the areas that this PR affects.

- [ ] Docs
- [ ] Installation
- [ ] Performance and Scalability
- [ ] Security
- [x] Test and/or Release
- [ ] User Experience

## Issue Ref (Optional)

Fixes #159

## Notes

Quite simplistic approach, which might not be rock solid (see comments in the code), but should do the trick for now.
