### PR TITLE
Patch csi-attacher Makefile to use implicit architecture for buildx on v3.0.0

### DIFF
--- a/build/csi-external-attacher/Dockerfile
+++ b/build/csi-external-attacher/Dockerfile
@@ -1,13 +1,16 @@
 FROM --platform=$BUILDPLATFORM golang:1.13 AS builder
 
-ARG VERSION=2.2.0
+ARG VERSION=3.0.0
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 
 WORKDIR /go/src/github.com/kubernetes-csi/external-attacher/
 
+COPY build.make.patch /build.make.patch
+
+RUN apt-get update && apt-get install -y patch
 RUN git clone --depth 1 -b "v${VERSION}" https://github.com/kubernetes-csi/external-attacher.git . \
-     && GOARCH=$(echo $TARGETPLATFORM | cut -f2 -d '/') make build
+     && patch -u release-tools/build.make -i /build.make.patch && GOARCH=$(echo $TARGETPLATFORM | cut -f2 -d '/') make build
 
 FROM gcr.io/distroless/static:nonroot
 

--- a/build/csi-external-attacher/build.make.patch
+++ b/build/csi-external-attacher/build.make.patch
@@ -1,0 +1,11 @@
+--- build.make	2020-09-25 12:33:11.986705136 +0100
++++ build.make.new	2020-09-25 14:17:41.915499663 +0100
+@@ -74,7 +74,7 @@
+ $(CMDS:%=build-%): build-%: check-go-version-go
+ 	mkdir -p bin
+ 	echo '$(BUILD_PLATFORMS)' | tr ';' '\n' | while read -r os arch suffix; do \
+-		if ! (set -x; CGO_ENABLED=0 GOOS="$$os" GOARCH="$$arch" go build $(GOFLAGS_VENDOR) -a -ldflags '-X main.version=$(REV) -extldflags "-static"' -o "./bin/$*$$suffix" ./cmd/$*); then \
++		if ! (set -x; CGO_ENABLED=0 GOOS="$$os" go build $(GOFLAGS_VENDOR) -a -ldflags '-X main.version=$(REV) -extldflags "-static"' -o "./bin/$*$$suffix" ./cmd/$*); then \
+ 			echo "Building $* for GOOS=$$os GOARCH=$$arch failed, see error(s) above."; \
+ 			exit 1; \
+ 		fi; \


### PR DESCRIPTION
# Description

A similar patching approach as used in #154, remove the GOARCH parameter from the Makefile so it behaves correctly under buildx.

## Type Of Change

To help us figure out who should review this PR, please put an X in all the areas that this PR affects.

- [ ] Docs
- [ ] Installation
- [ ] Performance and Scalability
- [ ] Security
- [x] Test and/or Release
- [ ] User Experience

## Issue Ref (Optional)

Fixes #166

## Notes

Was used to create `jamesorlakin/multiarch-csi-attacher:3.0.0`. I ran `file` in the build script to verify it's and aarch64 binary, but have not tested on real hardware.
