### PR TITLE
Patch Makefile to not override GOARCH for csi-resizer v1.0.0+

### DIFF
--- a/build/csi-external-resizer/Dockerfile
+++ b/build/csi-external-resizer/Dockerfile
@@ -1,13 +1,16 @@
 FROM --platform=$BUILDPLATFORM golang:1.13 AS builder
 
-ARG VERSION=0.5.0
+ARG VERSION=1.0.0
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 
 WORKDIR /go/src/github.com/kubernetes-csi/external-resizer/
 
+COPY build.make.patch /build.make.patch
+
+RUN apt-get update && apt-get install -y patch
 RUN git clone --depth 1 -b "v${VERSION}" https://github.com/kubernetes-csi/external-resizer.git . \
-     && GOARCH=$(echo $TARGETPLATFORM | cut -f2 -d '/') make build
+     && patch -u release-tools/build.make -i /build.make.patch && GOARCH=$(echo $TARGETPLATFORM | cut -f2 -d '/') make build
 
 FROM gcr.io/distroless/static:nonroot
 

--- a/build/csi-external-resizer/build.make.patch
+++ b/build/csi-external-resizer/build.make.patch
@@ -1,0 +1,11 @@
+--- build.make	2020-09-27 11:10:40.917111259 +0100
++++ build.make.new	2020-09-27 11:10:47.241142618 +0100
+@@ -74,7 +74,7 @@
+ $(CMDS:%=build-%): build-%: check-go-version-go
+ 	mkdir -p bin
+ 	echo '$(BUILD_PLATFORMS)' | tr ';' '\n' | while read -r os arch suffix; do \
+-		if ! (set -x; CGO_ENABLED=0 GOOS="$$os" GOARCH="$$arch" go build $(GOFLAGS_VENDOR) -a -ldflags '-X main.version=$(REV) -extldflags "-static"' -o "./bin/$*$$suffix" ./cmd/$*); then \
++		if ! (set -x; CGO_ENABLED=0 GOOS="$$os" go build $(GOFLAGS_VENDOR) -a -ldflags '-X main.version=$(REV) -extldflags "-static"' -o "./bin/$*$$suffix" ./cmd/$*); then \
+ 			echo "Building $* for GOOS=$$os GOARCH=$$arch failed, see error(s) above."; \
+ 			exit 1; \
+ 		fi; \


### PR DESCRIPTION
# Description

Another Makefile patch for the last of the CSI images (I think) to fix arm64 images not ending up being for arm.

## Type Of Change

To help us figure out who should review this PR, please put an X in all the areas that this PR affects.

- [ ] Docs
- [ ] Installation
- [ ] Performance and Scalability
- [ ] Security
- [x] Test and/or Release
- [ ] User Experience

## Issue Ref (Optional)

No issue was opened for this, but the previous v1.0.0 image would've had the wrong architecture.