### PR TITLE
Fix failing arm/v7 builds

### DIFF
--- a/.github/workflows/cloudflared.yml
+++ b/.github/workflows/cloudflared.yml
@@ -48,7 +48,7 @@ jobs:
           build-args: VERSION=${{ steps.prep.outputs.version }}
           context: ${{ steps.prep.outputs.base_dir }}/
           file: ${{ steps.prep.outputs.base_dir }}/Dockerfile
-          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             raspbernetes/cloudflared:${{ github.sha }}
@@ -60,7 +60,7 @@ jobs:
           build-args: VERSION=${{ steps.prep.outputs.version }}
           context: ${{ steps.prep.outputs.base_dir }}/
           file: ${{ steps.prep.outputs.base_dir }}/Dockerfile
-          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             raspbernetes/cloudflared:latest

--- a/.github/workflows/kustomize.yml
+++ b/.github/workflows/kustomize.yml
@@ -53,7 +53,7 @@ jobs:
           build-args: VERSION=${{ steps.prep.outputs.version }}
           context: ${{ steps.prep.outputs.base_dir }}/
           file: ${{ steps.prep.outputs.base_dir }}/Dockerfile
-          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             raspbernetes/kustomize:${{ github.sha }}
@@ -65,7 +65,7 @@ jobs:
           build-args: VERSION=${{ steps.prep.outputs.version }}
           context: ${{ steps.prep.outputs.base_dir }}/
           file: ${{ steps.prep.outputs.base_dir }}/Dockerfile
-          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             raspbernetes/kustomize:latest

--- a/.github/workflows/prometheus-operator-config-reloader.yml
+++ b/.github/workflows/prometheus-operator-config-reloader.yml
@@ -47,7 +47,7 @@ jobs:
         if: github.ref != 'refs/heads/master'
         run: |
           docker buildx build \
-            --platform linux/amd64,linux/arm64,linux/arm/v7 \
+            --platform linux/amd64,linux/arm64 \
             --build-arg=VERSION=${{ env.VERSION }} \
             --tag raspbernetes/prometheus-operator-config-reloader:${{ github.sha }} \
             --file ./build/prometheus-operator-config-reloader/Dockerfile \
@@ -58,7 +58,7 @@ jobs:
         if: github.ref == 'refs/heads/master'
         run: |
           docker buildx build \
-            --platform linux/amd64,linux/arm64,linux/arm/v7 \
+            --platform linux/amd64,linux/arm64 \
             --build-arg=VERSION=${{ env.VERSION }} \
             --tag raspbernetes/prometheus-operator-config-reloader:latest \
             --tag raspbernetes/prometheus-operator-config-reloader:${{ env.VERSION }} \

--- a/.github/workflows/sops.yml
+++ b/.github/workflows/sops.yml
@@ -48,7 +48,7 @@ jobs:
           build-args: VERSION=${{ steps.prep.outputs.version }}
           context: ${{ steps.prep.outputs.base_dir }}/
           file: ${{ steps.prep.outputs.base_dir }}/Dockerfile
-          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             raspbernetes/sops:${{ github.sha }}
@@ -60,7 +60,7 @@ jobs:
           build-args: VERSION=${{ steps.prep.outputs.version }}
           context: ${{ steps.prep.outputs.base_dir }}/
           file: ${{ steps.prep.outputs.base_dir }}/Dockerfile
-          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             raspbernetes/sops:latest


### PR DESCRIPTION
# Description

Removing linux/arm/v7 architecture as the platform is now missing from
the distroless image.

## Type Of Change

To help us figure out who should review this PR, please put an X in all the areas that this PR affects.

- [ ] Docs
- [ ] Installation
- [ ] Performance and Scalability
- [ ] Security
- [X] Test and/or Release
- [ ] User Experience

## Notes

Fixes required for broken PR #156 
