### PR TITLE
Fixes error in kured becasue of missing tzdata

### DIFF
--- a/build/kured/Dockerfile
+++ b/build/kured/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.15-alpine as build
 
-ARG VERSION=1.3.0
+ARG VERSION=1.5.1
 ARG KUBECTL_VERSION=v1.15.10
 ARG TARGETPLATFORM
 
@@ -16,9 +16,11 @@ RUN export GOOS=$(echo ${TARGETPLATFORM} | cut -d / -f1) && \
     export GOARM=$(echo ${TARGETPLATFORM} | cut -d / -f3 | cut -c2-) && \
     curl -L -o /usr/bin/kubectl "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${GOARCH}/kubectl" && \
     git clone --depth 1 -b ${VERSION} https://github.com/weaveworks/kured.git . && \
-    go build -o kured ./cmd/kured
+    go build -ldflags "-X main.version=${VERSION}" -o kured ./cmd/kured
 
 FROM alpine:3.12.1
+
+RUN apk add --no-cache tzdata
 
 COPY --from=build /usr/bin/kubectl /usr/bin/kubectl
 RUN chmod +x /usr/bin/kubectl


### PR DESCRIPTION
Fixes error in kured becasue of missing tzdata

Also updates to include Version when building kured

Signed-off-by: Vicente Zepeda Mas <vzepedamas@suse.com>

# Description

There is an error reported in `kured` repository regarding a failed [deployment](https://github.com/weaveworks/kured/issues/175), it is using the the `raspbernetes/kured` image, after testing for a while I realized that the `tzdata` package was missing and that is creating the error.

I added also the `ldflags` needed to display the version running of kured, much needed when debuging.

And changed the default version to the latest one.

## Type Of Change

To help us figure out who should review this PR, please put an X in all the areas that this PR affects.

- [ ] Docs

- [X] Installation

- [ ] Performance and Scalability
- [ ] Security
- [X] Test and/or Release
- [ ] User Experience

## Issue Ref (Optional)

Fixes #189 
Which issue(s) this PR fixes (optional, using fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when the PR gets merged): Fixes #

## Notes

Add special notes for your reviewer here.
