### PR TITLE
Removes v from VERSION var.

### DIFF
--- a/build/kubectl/Dockerfile
+++ b/build/kubectl/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.15-alpine as build
 
 ARG TARGETOS
 ARG TARGETARCH
-ARG VERSION=v1.18.2
+ARG VERSION=1.18.2
 
 WORKDIR /home/alpine
 


### PR DESCRIPTION
# Description

An extra v in the VERSION var/arg in the kubectl build's Dockerfile is causing an incorrect URL to curl / download kubectl. 

## Checklist

- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://developercertificate.org/)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] All pre-commit hook validation passed successfully.
- [x] All commits contain a well-written commit description including a title, description, and a Fixes: #XXX line if the commit addresses a particular GitHub issue.
- [x] All workflow validation and compliance checks are passing.

## Issue Ref (Optional)

Which issue(s) this PR fixes (optional, using fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when the PR gets merged): Fixes #

## Notes

Add special notes for your reviewer here.
