### PR TITLE
fix nfd build, modernize buildx actions

### DIFF
--- a/.github/workflows/node-feature-discovery.yml
+++ b/.github/workflows/node-feature-discovery.yml
@@ -46,7 +46,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-      - name: Build Container Image - Git Reference
+      - name: Build Full Container Image - Git Reference
         if: github.ref != 'refs/heads/master'
         run: |
           docker buildx build --build-arg=VERSION=$${ env.VERSION }} \
@@ -59,6 +59,10 @@ jobs:
             --file ./node-feature-discovery/Dockerfile \
             ./node-feature-discovery/ \
             --output "type=image,push=true"
+
+      - name: Build Minimal Container Image - Git Reference
+        if: github.ref != 'refs/heads/master'
+        run: |
           docker buildx build --build-arg=VERSION=$${ env.VERSION }} \
             --platform linux/amd64,linux/arm64,linux/arm/v7 \
             --target minimal \
@@ -70,7 +74,7 @@ jobs:
             ./node-feature-discovery/ \
             --output "type=image,push=true"
 
-      - name: Build Container Image - Release
+      - name: Build Full Container Image - Release
         if: github.ref == 'refs/heads/master'
         run: |
           docker buildx build --build-arg=VERSION=$${ env.VERSION }} \
@@ -85,6 +89,10 @@ jobs:
             --file ./node-feature-discovery/Dockerfile \
             ./node-feature-discovery/ \
             --output "type=image,push=true"
+
+      - name: Build Minimal Container Image - Release
+        if: github.ref == 'refs/heads/master'
+        run: |
           docker buildx build --build-arg=VERSION=$${ env.VERSION }} \
             --platform linux/amd64,linux/arm64,linux/arm/v7 \
             --target minimal \

--- a/.github/workflows/node-feature-discovery.yml
+++ b/.github/workflows/node-feature-discovery.yml
@@ -36,11 +36,10 @@ jobs:
 
     - name: Patch node-feature-discovery Dockerfile
       id: patch
-      env:
-        NFD_BASE_DIR: node-feature-discovery
       run: |
+        NFD_BASE_DIR=node-feature-discovery
         echo ::set-output name=nfd_base_dir::${NFD_BASE_DIR}
-        patch -i ${{ steps.prep.outputs.base_dir }}/build.Dockerfile.patch -u ${{ NFD_BASE_DIR }}/Dockerfile
+        patch -i ${{ steps.prep.outputs.base_dir }}/build.Dockerfile.patch -u ${NFD_BASE_DIR}/Dockerfile
 
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/node-feature-discovery.yml
+++ b/.github/workflows/node-feature-discovery.yml
@@ -53,8 +53,8 @@ jobs:
             --platform linux/amd64,linux/arm64,linux/arm/v7 \
             --target full \
             --build-arg=HOSTMOUNT_PREFIX=/host- \
-            --build-arg BASE_IMAGE_FULL="debian:buster-slim" \
-            --build-arg BASE_IMAGE_MINIMAL="gcr.io/distroless/base" \
+            --build-arg=BASE_IMAGE_FULL="debian:buster-slim" \
+            --build-arg=BASE_IMAGE_MINIMAL="gcr.io/distroless/base" \
             --tag raspbernetes/node-feature-discovery:${{ github.sha }} \
             --file ./node-feature-discovery/Dockerfile \
             ./node-feature-discovery/ \
@@ -67,8 +67,8 @@ jobs:
             --platform linux/amd64,linux/arm64,linux/arm/v7 \
             --target minimal \
             --build-arg=HOSTMOUNT_PREFIX=/host- \
-            --build-arg BASE_IMAGE_FULL="debian:buster-slim" \
-            --build-arg BASE_IMAGE_MINIMAL="gcr.io/distroless/base" \
+            --build-arg=BASE_IMAGE_FULL="debian:buster-slim" \
+            --build-arg=BASE_IMAGE_MINIMAL="gcr.io/distroless/base" \
             --tag raspbernetes/node-feature-discovery:${{ github.sha }}-minimal \
             --file ./node-feature-discovery/Dockerfile \
             ./node-feature-discovery/ \
@@ -81,8 +81,8 @@ jobs:
             --platform linux/amd64,linux/arm64,linux/arm/v7 \
             --target full \
             --build-arg=HOSTMOUNT_PREFIX=/host- \
-            --build-arg BASE_IMAGE_FULL="debian:buster-slim" \
-            --build-arg BASE_IMAGE_MINIMAL="gcr.io/distroless/base" \
+            --build-arg=BASE_IMAGE_FULL="debian:buster-slim" \
+            --build-arg=BASE_IMAGE_MINIMAL="gcr.io/distroless/base" \
             --tag k8sathome/node-feature-discovery:latest \
             --tag raspbernetes/node-feature-discovery:${{ env.VERSION }} \
             --tag k8sathome/node-feature-discovery:${{ env.VERSION }} \
@@ -97,8 +97,8 @@ jobs:
             --platform linux/amd64,linux/arm64,linux/arm/v7 \
             --target minimal \
             --build-arg=HOSTMOUNT_PREFIX=/host- \
-            --build-arg BASE_IMAGE_FULL="debian:buster-slim" \
-            --build-arg BASE_IMAGE_MINIMAL="gcr.io/distroless/base" \
+            --build-arg=BASE_IMAGE_FULL="debian:buster-slim" \
+            --build-arg=BASE_IMAGE_MINIMAL="gcr.io/distroless/base" \
             --tag k8sathome/node-feature-discovery:latest-minimal \
             --tag raspbernetes/node-feature-discovery:${{ env.VERSION }}-minimal \
             --tag k8sathome/node-feature-discovery:${{ env.VERSION }}-minimal \

--- a/.github/workflows/node-feature-discovery.yml
+++ b/.github/workflows/node-feature-discovery.yml
@@ -3,32 +3,48 @@ name: node-feature-discovery
 on:
   push:
     paths:
-      - '.github/workflows/node-feature-discovery.yml'
-      - 'build/node-feature-discovery/**'
-      - '!build/node-feature-discovery/*.md'
+    - '.github/workflows/node-feature-discovery.yml'
+    - 'build/node-feature-discovery/**'
+    - '!build/node-feature-discovery/*.md'
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    env:
-      VERSION: $(cat build/node-feature-discovery/.version)
+  prepare:
+    runs-on: ubuntu-20.04
+    outputs:
+      version: ${{ steps.prep.outputs.version }}
+      base_dir: ${{ steps.prep.outputs.base_dir }}
+      nfd_base_dir: ${{ steps.patch.outputs.nfd_base_dir }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+    - name: Checkout
+      uses: actions/checkout@v2
 
-      - name: Prepare
-        id: prep
-        run: |
-          BASE_DIR=build/node-feature-discovery
-          VERSION=$(cat ${BASE_DIR}/.version)
-          echo ::set-output name=version::${VERSION}
-          echo ::set-output name=base_dir::${BASE_DIR}
+    - name: Prepare
+      id: prep
+      run: |
+        BASE_DIR=build/node-feature-discovery
+        VERSION=$(cat ${BASE_DIR}/.version)
+        echo ::set-output name=base_dir::${BASE_DIR}
+        echo ::set-output name=version::${VERSION}
 
-      - name: Checkout node-feature-discovery repo
-        uses: actions/checkout@v2
-        with:
-          repository: kubernetes-sigs/node-feature-discovery
-          path: node-feature-discovery
+    - name: Checkout node-feature-discovery repo
+      uses: actions/checkout@v2
+      with:
+        repository: kubernetes-sigs/node-feature-discovery
+        branch: ${{ steps.prep.outputs.version }}
+        path: node-feature-discovery
+        depth: 1
+
+    - name: Patch node-feature-discovery Dockerfile
+      id: patch
+      run: |
+        NFD_BASE_DIR=node-feature-discovery
+        echo ::set-output name=nfd_base_dir::${NFD_BASE_DIR}
+        patch -i ${{ steps.prep.outputs.base_dir }}/build.Dockerfile.patch -u ${{ NFD_BASE_DIR }}/Dockerfile
+
+  build:
+    runs-on: ubuntu-20.04
+    needs: prepare
+    steps:
 
       - name: Set up QEMU
         id: qemu
@@ -48,60 +64,70 @@ jobs:
 
       - name: Build Full Container Image - Git Reference
         if: github.ref != 'refs/heads/master'
-        run: |
-          docker buildx build --build-arg=VERSION=${{ env.VERSION }} \
-            --platform linux/amd64,linux/arm64,linux/arm/v7 \
-            --target full \
-            --build-arg=HOSTMOUNT_PREFIX=/host- \
-            --build-arg=BASE_IMAGE_FULL="debian:buster-slim" \
-            --build-arg=BASE_IMAGE_MINIMAL="gcr.io/distroless/base" \
-            --tag raspbernetes/node-feature-discovery:${{ github.sha }} \
-            --file ./node-feature-discovery/Dockerfile \
-            ./node-feature-discovery/ \
-            --output "type=image,push=true"
+        uses: docker/build-push-action@v2
+        with:
+          plaforms: linux/amd64,linux/arm64,linux/arm/v7
+          target: full
+          build-args: |
+            VERSION=${{ needs.prepare.outputs.version }}
+            BASE_IMAGE_FULL="debian:buster-slim"
+            BASE_IMAGE_MINIMAL="gcr.io/distroless/base"
+            HOSTMOUNT_PREFIX=/host-
+          file: ${{ needs.prepare.outputs.nfd_base_dir }}/Dockerfile
+          context: ${{ needs.prepare.outputs.nfd_base_dir }}
+          tags: raspbernetes/node-feature-discovery:${{ github.sha }}
+          push: true
 
       - name: Build Minimal Container Image - Git Reference
         if: github.ref != 'refs/heads/master'
-        run: |
-          docker buildx build --build-arg=VERSION=${{ env.VERSION }} \
-            --platform linux/amd64,linux/arm64,linux/arm/v7 \
-            --target minimal \
-            --build-arg=HOSTMOUNT_PREFIX=/host- \
-            --build-arg=BASE_IMAGE_FULL="debian:buster-slim" \
-            --build-arg=BASE_IMAGE_MINIMAL="gcr.io/distroless/base" \
-            --tag raspbernetes/node-feature-discovery:${{ github.sha }}-minimal \
-            --file ./node-feature-discovery/Dockerfile \
-            ./node-feature-discovery/ \
-            --output "type=image,push=true"
+        uses: docker/build-push-action@v2
+        with:
+          plaforms: linux/amd64,linux/arm64,linux/arm/v7
+          target: minimal
+          build-args: |
+            VERSION=${{ needs.prepare.outputs.version }}
+            BASE_IMAGE_FULL="debian:buster-slim"
+            BASE_IMAGE_MINIMAL="gcr.io/distroless/base"
+            HOSTMOUNT_PREFIX=/host-
+          file: ${{ needs.prepare.outputs.nfd_base_dir }}/Dockerfile
+          context: ${{ needs.prepare.outputs.nfd_base_dir }}
+          tags: raspbernetes/node-feature-discovery:${{ github.sha }}-minimal
+          push: true
 
       - name: Build Full Container Image - Release
         if: github.ref == 'refs/heads/master'
-        run: |
-          docker buildx build --build-arg=VERSION=${{ env.VERSION }} \
-            --platform linux/amd64,linux/arm64,linux/arm/v7 \
-            --target full \
-            --build-arg=HOSTMOUNT_PREFIX=/host- \
-            --build-arg=BASE_IMAGE_FULL="debian:buster-slim" \
-            --build-arg=BASE_IMAGE_MINIMAL="gcr.io/distroless/base" \
-            --tag k8sathome/node-feature-discovery:latest \
-            --tag raspbernetes/node-feature-discovery:${{ env.VERSION }} \
-            --tag k8sathome/node-feature-discovery:${{ env.VERSION }} \
-            --file ./node-feature-discovery/Dockerfile \
-            ./node-feature-discovery/ \
-            --output "type=image,push=true"
+        uses: docker/build-push-action@v2
+        with:
+          plaforms: linux/amd64,linux/arm64,linux/arm/v7
+          target: full
+          build-args: |
+            VERSION=${{ needs.prepare.outputs.version }}
+            BASE_IMAGE_FULL="debian:buster-slim"
+            BASE_IMAGE_MINIMAL="gcr.io/distroless/base"
+            HOSTMOUNT_PREFIX=/host-
+          file: ${{ needs.prepare.outputs.nfd_base_dir }}/Dockerfile
+          context: ${{ needs.prepare.outputs.nfd_base_dir }}
+          tags: |
+            k8sathome/node-feature-discovery:latest
+            k8sathome/node-feature-discovery:${{ needs.prepare.outputs.version }}
+            raspbernetes/node-feature-discovery:${{ needs.prepare.outputs.version }}
+          push: true
 
       - name: Build Minimal Container Image - Release
         if: github.ref == 'refs/heads/master'
-        run: |
-          docker buildx build --build-arg=VERSION=${{ env.VERSION }} \
-            --platform linux/amd64,linux/arm64,linux/arm/v7 \
-            --target minimal \
-            --build-arg=HOSTMOUNT_PREFIX=/host- \
-            --build-arg=BASE_IMAGE_FULL="debian:buster-slim" \
-            --build-arg=BASE_IMAGE_MINIMAL="gcr.io/distroless/base" \
-            --tag k8sathome/node-feature-discovery:latest-minimal \
-            --tag raspbernetes/node-feature-discovery:${{ env.VERSION }}-minimal \
-            --tag k8sathome/node-feature-discovery:${{ env.VERSION }}-minimal \
-            --file ./node-feature-discovery/Dockerfile \
-            ./node-feature-discovery/ \
-            --output "type=image,push=true"
+        uses: docker/build-push-action@v2
+        with:
+          plaforms: linux/amd64,linux/arm64,linux/arm/v7
+          target: minimal
+          build-args: |
+            VERSION=${{ needs.prepare.outputs.version }}
+            BASE_IMAGE_FULL="debian:buster-slim"
+            BASE_IMAGE_MINIMAL="gcr.io/distroless/base"
+            HOSTMOUNT_PREFIX=/host-
+          file: ${{ needs.prepare.outputs.nfd_base_dir }}/Dockerfile
+          context: ${{ needs.prepare.outputs.nfd_base_dir }}
+          tags: |
+            k8sathome/node-feature-discovery:latest-minimal
+            k8sathome/node-feature-discovery:${{ needs.prepare.outputs.version }}-minimal
+            raspbernetes/node-feature-discovery:${{ needs.prepare.outputs.version }}-minimal
+          push: true

--- a/.github/workflows/node-feature-discovery.yml
+++ b/.github/workflows/node-feature-discovery.yml
@@ -8,12 +8,9 @@ on:
     - '!build/node-feature-discovery/*.md'
 
 jobs:
-  prepare:
+  build:
     runs-on: ubuntu-20.04
-    outputs:
-      version: ${{ steps.prep.outputs.version }}
-      base_dir: ${{ steps.prep.outputs.base_dir }}
-      nfd_base_dir: ${{ steps.patch.outputs.nfd_base_dir }}
+    needs: prepare
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -23,111 +20,105 @@ jobs:
       run: |
         BASE_DIR=build/node-feature-discovery
         VERSION=$(cat ${BASE_DIR}/.version)
+        NFD_BASE_DIR=node-feature-discovery
         echo ::set-output name=base_dir::${BASE_DIR}
         echo ::set-output name=version::${VERSION}
+        echo ::set-output name=nfd_base_dir::${NFD_BASE_DIR}
 
     - name: Checkout node-feature-discovery repo
       uses: actions/checkout@v2
       with:
         repository: kubernetes-sigs/node-feature-discovery
-        branch: ${{ steps.prep.outputs.version }}
+        ref: ${{ steps.prep.outputs.version }}
         path: node-feature-discovery
-        depth: 1
 
     - name: Patch node-feature-discovery Dockerfile
       id: patch
       run: |
-        NFD_BASE_DIR=node-feature-discovery
-        echo ::set-output name=nfd_base_dir::${NFD_BASE_DIR}
-        patch -i ${{ steps.prep.outputs.base_dir }}/build.Dockerfile.patch -u ${NFD_BASE_DIR}/Dockerfile
+        patch -i ${{ steps.prep.outputs.base_dir }}/build.Dockerfile.patch -u ${{ steps.prep.outputs.nfd_base_dir }}/Dockerfile
 
-  build:
-    runs-on: ubuntu-20.04
-    needs: prepare
-    steps:
+    - name: Set up QEMU
+      id: qemu
+      uses: docker/setup-qemu-action@v1
+      with:
+        platforms: amd64,arm64,arm
 
-      - name: Set up QEMU
-        id: qemu
-        uses: docker/setup-qemu-action@v1
-        with:
-          platforms: amd64,arm64,arm
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
 
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v1
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+    - name: Build Full Container Image - Git Reference
+      if: github.ref != 'refs/heads/master'
+      uses: docker/build-push-action@v2
+      with:
+        platforms: linux/amd64,linux/arm64,linux/arm/v7
+        target: full
+        build-args: |
+          VERSION=${{ steps.prep.outputs.version }}
+          BASE_IMAGE_FULL="debian:buster-slim"
+          BASE_IMAGE_MINIMAL="gcr.io/distroless/base"
+          HOSTMOUNT_PREFIX=/host-
+        file: ${{ steps.prep.outputs.nfd_base_dir }}/Dockerfile
+        context: ${{ steps.prep.outputs.nfd_base_dir }}
+        tags: raspbernetes/node-feature-discovery:${{ github.sha }}
+        push: true
 
-      - name: Build Full Container Image - Git Reference
-        if: github.ref != 'refs/heads/master'
-        uses: docker/build-push-action@v2
-        with:
-          plaforms: linux/amd64,linux/arm64,linux/arm/v7
-          target: full
-          build-args: |
-            VERSION=${{ needs.prepare.outputs.version }}
-            BASE_IMAGE_FULL="debian:buster-slim"
-            BASE_IMAGE_MINIMAL="gcr.io/distroless/base"
-            HOSTMOUNT_PREFIX=/host-
-          file: ${{ needs.prepare.outputs.nfd_base_dir }}/Dockerfile
-          context: ${{ needs.prepare.outputs.nfd_base_dir }}
-          tags: raspbernetes/node-feature-discovery:${{ github.sha }}
-          push: true
+    - name: Build Minimal Container Image - Git Reference
+      if: github.ref != 'refs/heads/master'
+      uses: docker/build-push-action@v2
+      with:
+        platforms: linux/amd64,linux/arm64,linux/arm/v7
+        target: minimal
+        build-args: |
+          VERSION=${{ steps.prep.outputs.version }}
+          BASE_IMAGE_FULL="debian:buster-slim"
+          BASE_IMAGE_MINIMAL="gcr.io/distroless/base"
+          HOSTMOUNT_PREFIX=/host-
+        file: ${{ steps.prep.outputs.nfd_base_dir }}/Dockerfile
+        context: ${{ steps.prep.outputs.nfd_base_dir }}
+        tags: raspbernetes/node-feature-discovery:${{ github.sha }}-minimal
+        push: true
 
-      - name: Build Minimal Container Image - Git Reference
-        if: github.ref != 'refs/heads/master'
-        uses: docker/build-push-action@v2
-        with:
-          plaforms: linux/amd64,linux/arm64,linux/arm/v7
-          target: minimal
-          build-args: |
-            VERSION=${{ needs.prepare.outputs.version }}
-            BASE_IMAGE_FULL="debian:buster-slim"
-            BASE_IMAGE_MINIMAL="gcr.io/distroless/base"
-            HOSTMOUNT_PREFIX=/host-
-          file: ${{ needs.prepare.outputs.nfd_base_dir }}/Dockerfile
-          context: ${{ needs.prepare.outputs.nfd_base_dir }}
-          tags: raspbernetes/node-feature-discovery:${{ github.sha }}-minimal
-          push: true
+    - name: Build Full Container Image - Release
+      if: github.ref == 'refs/heads/master'
+      uses: docker/build-push-action@v2
+      with:
+        platforms: linux/amd64,linux/arm64,linux/arm/v7
+        target: full
+        build-args: |
+          VERSION=${{ steps.prep.outputs.version }}
+          BASE_IMAGE_FULL="debian:buster-slim"
+          BASE_IMAGE_MINIMAL="gcr.io/distroless/base"
+          HOSTMOUNT_PREFIX=/host-
+        file: ${{ steps.prep.outputs.nfd_base_dir }}/Dockerfile
+        context: ${{ steps.prep.outputs.nfd_base_dir }}
+        tags: |
+          k8sathome/node-feature-discovery:latest
+          k8sathome/node-feature-discovery:${{ steps.prep.outputs.version }}
+          raspbernetes/node-feature-discovery:${{ steps.prep.outputs.version }}
+        push: true
 
-      - name: Build Full Container Image - Release
-        if: github.ref == 'refs/heads/master'
-        uses: docker/build-push-action@v2
-        with:
-          plaforms: linux/amd64,linux/arm64,linux/arm/v7
-          target: full
-          build-args: |
-            VERSION=${{ needs.prepare.outputs.version }}
-            BASE_IMAGE_FULL="debian:buster-slim"
-            BASE_IMAGE_MINIMAL="gcr.io/distroless/base"
-            HOSTMOUNT_PREFIX=/host-
-          file: ${{ needs.prepare.outputs.nfd_base_dir }}/Dockerfile
-          context: ${{ needs.prepare.outputs.nfd_base_dir }}
-          tags: |
-            k8sathome/node-feature-discovery:latest
-            k8sathome/node-feature-discovery:${{ needs.prepare.outputs.version }}
-            raspbernetes/node-feature-discovery:${{ needs.prepare.outputs.version }}
-          push: true
-
-      - name: Build Minimal Container Image - Release
-        if: github.ref == 'refs/heads/master'
-        uses: docker/build-push-action@v2
-        with:
-          plaforms: linux/amd64,linux/arm64,linux/arm/v7
-          target: minimal
-          build-args: |
-            VERSION=${{ needs.prepare.outputs.version }}
-            BASE_IMAGE_FULL="debian:buster-slim"
-            BASE_IMAGE_MINIMAL="gcr.io/distroless/base"
-            HOSTMOUNT_PREFIX=/host-
-          file: ${{ needs.prepare.outputs.nfd_base_dir }}/Dockerfile
-          context: ${{ needs.prepare.outputs.nfd_base_dir }}
-          tags: |
-            k8sathome/node-feature-discovery:latest-minimal
-            k8sathome/node-feature-discovery:${{ needs.prepare.outputs.version }}-minimal
-            raspbernetes/node-feature-discovery:${{ needs.prepare.outputs.version }}-minimal
-          push: true
+    - name: Build Minimal Container Image - Release
+      if: github.ref == 'refs/heads/master'
+      uses: docker/build-push-action@v2
+      with:
+        platforms: linux/amd64,linux/arm64,linux/arm/v7
+        target: minimal
+        build-args: |
+          VERSION=${{ steps.prep.outputs.version }}
+          BASE_IMAGE_FULL="debian:buster-slim"
+          BASE_IMAGE_MINIMAL="gcr.io/distroless/base"
+          HOSTMOUNT_PREFIX=/host-
+        file: ${{ steps.prep.outputs.nfd_base_dir }}/Dockerfile
+        context: ${{ steps.prep.outputs.nfd_base_dir }}
+        tags: |
+          k8sathome/node-feature-discovery:latest-minimal
+          k8sathome/node-feature-discovery:${{ steps.prep.outputs.version }}-minimal
+          raspbernetes/node-feature-discovery:${{ steps.prep.outputs.version }}-minimal
+        push: true

--- a/.github/workflows/node-feature-discovery.yml
+++ b/.github/workflows/node-feature-discovery.yml
@@ -36,8 +36,9 @@ jobs:
 
     - name: Patch node-feature-discovery Dockerfile
       id: patch
+      env:
+        NFD_BASE_DIR: node-feature-discovery
       run: |
-        NFD_BASE_DIR=node-feature-discovery
         echo ::set-output name=nfd_base_dir::${NFD_BASE_DIR}
         patch -i ${{ steps.prep.outputs.base_dir }}/build.Dockerfile.patch -u ${{ NFD_BASE_DIR }}/Dockerfile
 

--- a/.github/workflows/node-feature-discovery.yml
+++ b/.github/workflows/node-feature-discovery.yml
@@ -10,7 +10,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-20.04
-    needs: prepare
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/node-feature-discovery.yml
+++ b/.github/workflows/node-feature-discovery.yml
@@ -60,8 +60,8 @@ jobs:
         target: full
         build-args: |
           VERSION=${{ steps.prep.outputs.version }}
-          BASE_IMAGE_FULL="debian:buster-slim"
-          BASE_IMAGE_MINIMAL="gcr.io/distroless/base"
+          BASE_IMAGE_FULL=debian:buster-slim
+          BASE_IMAGE_MINIMAL=gcr.io/distroless/base
           HOSTMOUNT_PREFIX=/host-
         file: ${{ steps.prep.outputs.nfd_base_dir }}/Dockerfile
         context: ${{ steps.prep.outputs.nfd_base_dir }}
@@ -76,8 +76,8 @@ jobs:
         target: minimal
         build-args: |
           VERSION=${{ steps.prep.outputs.version }}
-          BASE_IMAGE_FULL="debian:buster-slim"
-          BASE_IMAGE_MINIMAL="gcr.io/distroless/base"
+          BASE_IMAGE_FULL=debian:buster-slim
+          BASE_IMAGE_MINIMAL=gcr.io/distroless/base
           HOSTMOUNT_PREFIX=/host-
         file: ${{ steps.prep.outputs.nfd_base_dir }}/Dockerfile
         context: ${{ steps.prep.outputs.nfd_base_dir }}
@@ -92,8 +92,8 @@ jobs:
         target: full
         build-args: |
           VERSION=${{ steps.prep.outputs.version }}
-          BASE_IMAGE_FULL="debian:buster-slim"
-          BASE_IMAGE_MINIMAL="gcr.io/distroless/base"
+          BASE_IMAGE_FULL=debian:buster-slim
+          BASE_IMAGE_MINIMAL=gcr.io/distroless/base
           HOSTMOUNT_PREFIX=/host-
         file: ${{ steps.prep.outputs.nfd_base_dir }}/Dockerfile
         context: ${{ steps.prep.outputs.nfd_base_dir }}
@@ -111,8 +111,8 @@ jobs:
         target: minimal
         build-args: |
           VERSION=${{ steps.prep.outputs.version }}
-          BASE_IMAGE_FULL="debian:buster-slim"
-          BASE_IMAGE_MINIMAL="gcr.io/distroless/base"
+          BASE_IMAGE_FULL=debian:buster-slim
+          BASE_IMAGE_MINIMAL=gcr.io/distroless/base
           HOSTMOUNT_PREFIX=/host-
         file: ${{ steps.prep.outputs.nfd_base_dir }}/Dockerfile
         context: ${{ steps.prep.outputs.nfd_base_dir }}

--- a/.github/workflows/node-feature-discovery.yml
+++ b/.github/workflows/node-feature-discovery.yml
@@ -45,6 +45,10 @@ jobs:
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@v1
+      with:
+        install: true
+        version: latest
+        driver-opts: image=moby/buildkit:latest
 
     - name: Login to DockerHub
       uses: docker/login-action@v1

--- a/.github/workflows/node-feature-discovery.yml
+++ b/.github/workflows/node-feature-discovery.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Build Full Container Image - Git Reference
         if: github.ref != 'refs/heads/master'
         run: |
-          docker buildx build --build-arg=VERSION=$${ env.VERSION }} \
+          docker buildx build --build-arg=VERSION=${{ env.VERSION }} \
             --platform linux/amd64,linux/arm64,linux/arm/v7 \
             --target full \
             --build-arg=HOSTMOUNT_PREFIX=/host- \
@@ -63,7 +63,7 @@ jobs:
       - name: Build Minimal Container Image - Git Reference
         if: github.ref != 'refs/heads/master'
         run: |
-          docker buildx build --build-arg=VERSION=$${ env.VERSION }} \
+          docker buildx build --build-arg=VERSION=${{ env.VERSION }} \
             --platform linux/amd64,linux/arm64,linux/arm/v7 \
             --target minimal \
             --build-arg=HOSTMOUNT_PREFIX=/host- \
@@ -77,7 +77,7 @@ jobs:
       - name: Build Full Container Image - Release
         if: github.ref == 'refs/heads/master'
         run: |
-          docker buildx build --build-arg=VERSION=$${ env.VERSION }} \
+          docker buildx build --build-arg=VERSION=${{ env.VERSION }} \
             --platform linux/amd64,linux/arm64,linux/arm/v7 \
             --target full \
             --build-arg=HOSTMOUNT_PREFIX=/host- \
@@ -93,7 +93,7 @@ jobs:
       - name: Build Minimal Container Image - Release
         if: github.ref == 'refs/heads/master'
         run: |
-          docker buildx build --build-arg=VERSION=$${ env.VERSION }} \
+          docker buildx build --build-arg=VERSION=${{ env.VERSION }} \
             --platform linux/amd64,linux/arm64,linux/arm/v7 \
             --target minimal \
             --build-arg=HOSTMOUNT_PREFIX=/host- \

--- a/.github/workflows/node-feature-discovery.yml
+++ b/.github/workflows/node-feature-discovery.yml
@@ -30,11 +30,15 @@ jobs:
           repository: kubernetes-sigs/node-feature-discovery
           path: node-feature-discovery
 
+      - name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: amd64,arm64,arm
+
       - name: Set up Docker Buildx
         id: buildx
-        uses: crazy-max/ghaction-docker-buildx@v3.3.1
-        with:
-          version: latest
+        uses: docker/setup-buildx-action@v1
 
       - name: Login to DockerHub
         uses: docker/login-action@v1
@@ -42,30 +46,54 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-      - name: Build Container Image
+      - name: Build Container Image - Git Reference
         if: github.ref != 'refs/heads/master'
         run: |
-          docker buildx build \
+          docker buildx build --build-arg=VERSION=$${ env.VERSION }} \
             --platform linux/amd64,linux/arm64,linux/arm/v7 \
-            --build-arg=VERSION=${{ env.VERSION }} \
-            --build-arg=NFD_VERSION=${{ env.VERSION }} \
+            --target full \
             --build-arg=HOSTMOUNT_PREFIX=/host- \
+            --build-arg BASE_IMAGE_FULL="debian:buster-slim" \
+            --build-arg BASE_IMAGE_MINIMAL="gcr.io/distroless/base" \
             --tag raspbernetes/node-feature-discovery:${{ github.sha }} \
             --file ./node-feature-discovery/Dockerfile \
             ./node-feature-discovery/ \
             --output "type=image,push=true"
+          docker buildx build --build-arg=VERSION=$${ env.VERSION }} \
+            --platform linux/amd64,linux/arm64,linux/arm/v7 \
+            --target minimal \
+            --build-arg=HOSTMOUNT_PREFIX=/host- \
+            --build-arg BASE_IMAGE_FULL="debian:buster-slim" \
+            --build-arg BASE_IMAGE_MINIMAL="gcr.io/distroless/base" \
+            --tag raspbernetes/node-feature-discovery:${{ github.sha }}-minimal \
+            --file ./node-feature-discovery/Dockerfile \
+            ./node-feature-discovery/ \
+            --output "type=image,push=true"
 
-      - name: Build Container Image
+      - name: Build Container Image - Release
         if: github.ref == 'refs/heads/master'
         run: |
-          docker buildx build \
+          docker buildx build --build-arg=VERSION=$${ env.VERSION }} \
             --platform linux/amd64,linux/arm64,linux/arm/v7 \
-            --build-arg=VERSION=${{ env.VERSION }} \
-            --build-arg=NFD_VERSION=${{ env.VERSION }} \
+            --target full \
             --build-arg=HOSTMOUNT_PREFIX=/host- \
+            --build-arg BASE_IMAGE_FULL="debian:buster-slim" \
+            --build-arg BASE_IMAGE_MINIMAL="gcr.io/distroless/base" \
             --tag k8sathome/node-feature-discovery:latest \
             --tag raspbernetes/node-feature-discovery:${{ env.VERSION }} \
             --tag k8sathome/node-feature-discovery:${{ env.VERSION }} \
+            --file ./node-feature-discovery/Dockerfile \
+            ./node-feature-discovery/ \
+            --output "type=image,push=true"
+          docker buildx build --build-arg=VERSION=$${ env.VERSION }} \
+            --platform linux/amd64,linux/arm64,linux/arm/v7 \
+            --target minimal \
+            --build-arg=HOSTMOUNT_PREFIX=/host- \
+            --build-arg BASE_IMAGE_FULL="debian:buster-slim" \
+            --build-arg BASE_IMAGE_MINIMAL="gcr.io/distroless/base" \
+            --tag k8sathome/node-feature-discovery:latest-minimal \
+            --tag raspbernetes/node-feature-discovery:${{ env.VERSION }}-minimal \
+            --tag k8sathome/node-feature-discovery:${{ env.VERSION }}-minimal \
             --file ./node-feature-discovery/Dockerfile \
             ./node-feature-discovery/ \
             --output "type=image,push=true"

--- a/build/node-feature-discovery/build.Dockerfile.patch
+++ b/build/node-feature-discovery/build.Dockerfile.patch
@@ -1,19 +1,17 @@
 diff --git a/Dockerfile b/Dockerfile
-index 3f76cc2..e8b30a7 100644
+index 3f76cc2..cb4520b 100644
 --- a/Dockerfile
 +++ b/Dockerfile
-@@ -1,12 +1,14 @@
- ARG BASE_IMAGE_FULL
- ARG BASE_IMAGE_MINIMAL
-+ARG TARGETARCH
+@@ -3,10 +3,11 @@ ARG BASE_IMAGE_MINIMAL
 
  # Build node feature discovery
  FROM golang:1.16.7-buster as builder
++ARG TARGETARCH
 
  # Download the grpc_health_probe bin
- RUN GRPC_HEALTH_PROBE_VERSION=v0.3.1 && \
+-RUN GRPC_HEALTH_PROBE_VERSION=v0.3.1 && \
 -    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
-+    GRPC_HEALTH_PROBE_ARCH=${TARGETARCH} && \
++RUN GRPC_HEALTH_PROBE_VERSION=v0.3.1 GRPC_HEALTH_PROBE_ARCH=${TARGETARCH} && \
 +    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${GRPC_HEALTH_PROBE_ARCH} && \
      chmod +x /bin/grpc_health_probe
 

--- a/build/node-feature-discovery/build.Dockerfile.patch
+++ b/build/node-feature-discovery/build.Dockerfile.patch
@@ -1,19 +1,20 @@
 diff --git a/Dockerfile b/Dockerfile
-index 3f76cc2..d4b43b0 100644
+index 3f76cc2..e8b30a7 100644
 --- a/Dockerfile
 +++ b/Dockerfile
-@@ -1,12 +1,13 @@
+@@ -1,12 +1,14 @@
  ARG BASE_IMAGE_FULL
  ARG BASE_IMAGE_MINIMAL
 +ARG TARGETARCH
- 
+
  # Build node feature discovery
  FROM golang:1.16.7-buster as builder
- 
+
  # Download the grpc_health_probe bin
  RUN GRPC_HEALTH_PROBE_VERSION=v0.3.1 && \
 -    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
-+    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH} && \
++    GRPC_HEALTH_PROBE_ARCH=${TARGETARCH} && \
++    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${GRPC_HEALTH_PROBE_ARCH} && \
      chmod +x /bin/grpc_health_probe
- 
+
  # Get (cache) deps in a separate layer

--- a/build/node-feature-discovery/build.Dockerfile.patch
+++ b/build/node-feature-discovery/build.Dockerfile.patch
@@ -1,0 +1,19 @@
+diff --git a/Dockerfile b/Dockerfile
+index 3f76cc2..d4b43b0 100644
+--- a/Dockerfile
++++ b/Dockerfile
+@@ -1,12 +1,13 @@
+ ARG BASE_IMAGE_FULL
+ ARG BASE_IMAGE_MINIMAL
++ARG TARGETARCH
+ 
+ # Build node feature discovery
+ FROM golang:1.16.7-buster as builder
+ 
+ # Download the grpc_health_probe bin
+ RUN GRPC_HEALTH_PROBE_VERSION=v0.3.1 && \
+-    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
++    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH} && \
+     chmod +x /bin/grpc_health_probe
+ 
+ # Get (cache) deps in a separate layer


### PR DESCRIPTION
Signed-off-by: Nick M <4718+rkage@users.noreply.github.com>

# Description

This is an attempt to fix the node-feature-discovery workflow.

* Updated Docker BuildX action to use the official Docker version
* use the official docker build-and-push action rather than use direct docker commands
* introduce a patch to the `Dockerfile` that properly downloads the appropriate GRPC health probe binary

